### PR TITLE
Add `allow_japanese_mobile_carrier` option

### DIFF
--- a/lib/validates_email_format_of.rb
+++ b/lib/validates_email_format_of.rb
@@ -46,7 +46,7 @@ module ValidatesEmailFormatOf
                           :domain_length => 255,
                           :local_length => 64,
                           :generate_message => false,
-                          :allow_japanese_mobile_carrier => false,
+                          :allow_jp_mobile_carrier_format => false,
                           }
       opts = options.merge(default_options) {|key, old, new| old}  # merge the default options into the specified options, retaining all specified options
 
@@ -70,7 +70,7 @@ module ValidatesEmailFormatOf
       if opts.has_key?(:with) # holdover from versions <= 1.4.7
         return [ opts[:message] ] unless email =~ opts[:with]
       else
-        return [ opts[:message] ] unless self.validate_local_part_syntax(local, allow_japanese_mobile_carrier: opts[:allow_japanese_mobile_carrier]) and self.validate_domain_part_syntax(domain)
+        return [ opts[:message] ] unless self.validate_local_part_syntax(local, allow_jp_mobile_carrier_format: opts[:allow_jp_mobile_carrier_format]) and self.validate_domain_part_syntax(domain)
       end
 
       if opts[:check_mx] and !self.validate_email_domain(email)
@@ -81,7 +81,7 @@ module ValidatesEmailFormatOf
   end
 
 
-  def self.validate_local_part_syntax(local, allow_japanese_mobile_carrier: false)
+  def self.validate_local_part_syntax(local, allow_jp_mobile_carrier_format: false)
     in_quoted_pair = false
     in_quoted_string = false
 
@@ -112,8 +112,8 @@ module ValidatesEmailFormatOf
 
       # period must be followed by something
       if ord == 46
-        return false if i == 0 or (!allow_japanese_mobile_carrier and i == local.length - 1) # can't be first or last char
-        next unless !allow_japanese_mobile_carrier and local[i+1].ord == 46 # can't be followed by a period
+        return false if i == 0 or (!allow_jp_mobile_carrier_format and i == local.length - 1) # can't be first or last char
+        next unless !allow_jp_mobile_carrier_format and local[i+1].ord == 46 # can't be followed by a period
       end
 
       return false

--- a/lib/validates_email_format_of.rb
+++ b/lib/validates_email_format_of.rb
@@ -45,7 +45,8 @@ module ValidatesEmailFormatOf
                           :mx_message => options[:generate_message] ? ERROR_MX_MESSAGE_I18N_KEY : (defined?(I18n) ? I18n.t(ERROR_MX_MESSAGE_I18N_KEY, :scope => [:activemodel, :errors, :messages], :default => DEFAULT_MX_MESSAGE) : DEFAULT_MX_MESSAGE),
                           :domain_length => 255,
                           :local_length => 64,
-                          :generate_message => false
+                          :generate_message => false,
+                          :allow_japanese_mobile_carrier => false,
                           }
       opts = options.merge(default_options) {|key, old, new| old}  # merge the default options into the specified options, retaining all specified options
 
@@ -69,7 +70,7 @@ module ValidatesEmailFormatOf
       if opts.has_key?(:with) # holdover from versions <= 1.4.7
         return [ opts[:message] ] unless email =~ opts[:with]
       else
-        return [ opts[:message] ] unless self.validate_local_part_syntax(local) and self.validate_domain_part_syntax(domain)
+        return [ opts[:message] ] unless self.validate_local_part_syntax(local, allow_japanese_mobile_carrier: opts[:allow_japanese_mobile_carrier]) and self.validate_domain_part_syntax(domain)
       end
 
       if opts[:check_mx] and !self.validate_email_domain(email)
@@ -80,7 +81,7 @@ module ValidatesEmailFormatOf
   end
 
 
-  def self.validate_local_part_syntax(local)
+  def self.validate_local_part_syntax(local, allow_japanese_mobile_carrier: false)
     in_quoted_pair = false
     in_quoted_string = false
 
@@ -111,8 +112,8 @@ module ValidatesEmailFormatOf
 
       # period must be followed by something
       if ord == 46
-        return false if i == 0 or i == local.length - 1 # can't be first or last char
-        next unless local[i+1].ord == 46 # can't be followed by a period
+        return false if i == 0 or (!allow_japanese_mobile_carrier and i == local.length - 1) # can't be first or last char
+        next unless !allow_japanese_mobile_carrier and local[i+1].ord == 46 # can't be followed by a period
       end
 
       return false

--- a/spec/validates_email_format_of_spec.rb
+++ b/spec/validates_email_format_of_spec.rb
@@ -161,6 +161,25 @@ describe ValidatesEmailFormatOf do
         it_should_behave_like :domain_length_limit, 100
       end
     end
+    describe "allow_japanese_mobile_carrier" do
+      describe "when using default" do
+        describe "foo..bar@example.com" do
+          it { should have_errors_on_email.because("does not appear to be a valid e-mail address") }
+        end
+        describe "foobar.@example.com" do
+          it { should have_errors_on_email.because("does not appear to be a valid e-mail address") }
+        end
+      end
+      describe "when overriding defaults" do
+        let(:options) { { :allow_japanese_mobile_carrier => true } }
+        describe "foo..bar@example.com" do
+          it { should_not have_errors_on_email }
+        end
+        describe "foobar.@example.com" do
+          it { should_not have_errors_on_email }
+        end
+      end
+    end
 
     describe "custom error messages" do
       describe 'invalid@example.' do

--- a/spec/validates_email_format_of_spec.rb
+++ b/spec/validates_email_format_of_spec.rb
@@ -161,7 +161,7 @@ describe ValidatesEmailFormatOf do
         it_should_behave_like :domain_length_limit, 100
       end
     end
-    describe "allow_japanese_mobile_carrier" do
+    describe "allow_jp_mobile_carrier_format" do
       describe "when using default" do
         describe "foo..bar@example.com" do
           it { should have_errors_on_email.because("does not appear to be a valid e-mail address") }
@@ -171,7 +171,7 @@ describe ValidatesEmailFormatOf do
         end
       end
       describe "when overriding defaults" do
-        let(:options) { { :allow_japanese_mobile_carrier => true } }
+        let(:options) { { :allow_jp_mobile_carrier_format => true } }
         describe "foo..bar@example.com" do
           it { should_not have_errors_on_email }
         end


### PR DESCRIPTION
Allow strings contain consecutive periods or ends with a period in local part
when allow_japanese_mobile_carrier is true.